### PR TITLE
Board 설계 및 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	runtimeOnly 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	runtimeOnly 'com.h2database:h2'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/jungle/dylan/api/config/SwaggerConfig.java
+++ b/src/main/java/jungle/dylan/api/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package jungle.dylan.api.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("BOARD API")
+                .description("Swagger for controller test")
+                .version("0.1.0"); // properties에서 읽어 오는 걸로 변경 예정
+    }
+}

--- a/src/main/java/jungle/dylan/api/constant/BoardResponseMessage.java
+++ b/src/main/java/jungle/dylan/api/constant/BoardResponseMessage.java
@@ -1,0 +1,17 @@
+package jungle.dylan.api.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BoardResponseMessage {
+    SUCCESS("success"),
+    WRITE_SUCCESS("write article id [%s] success"),
+    UPDATE_SUCCESS("update article id [%s] success"),
+    DELETE_SUCCESS("delete article id [%s] success"),
+    ;
+
+    private final String message;
+
+}

--- a/src/main/java/jungle/dylan/api/controller/BoardController.java
+++ b/src/main/java/jungle/dylan/api/controller/BoardController.java
@@ -51,4 +51,25 @@ public class BoardController {
                 .message(SUCCESS.getMessage())
                 .build();
     }
+
+    @PutMapping("{id}")
+    public ApiResponse<Object> updateBoard(@PathVariable Long id, @RequestBody BoardRequest boardRequest) {
+        BoardResponse updateBoard = boardService.update(id, boardRequest);
+
+        return ApiResponse.builder()
+                .status(HttpStatus.OK)
+                .data(updateBoard)
+                .message(String.format(UPDATE_SUCCESS.getMessage(), updateBoard.getId()))
+                .build();
+    }
+
+    @DeleteMapping("{id}")
+    public ApiResponse<Object> deleteBoard(@PathVariable Long id) {
+        Long deleteBoardId = boardService.delete(id);
+
+        return ApiResponse.builder()
+                .status(HttpStatus.OK)
+                .message(String.format(DELETE_SUCCESS.getMessage(), deleteBoardId))
+                .build();
+    }
 }

--- a/src/main/java/jungle/dylan/api/controller/BoardController.java
+++ b/src/main/java/jungle/dylan/api/controller/BoardController.java
@@ -1,0 +1,44 @@
+package jungle.dylan.api.controller;
+
+import jungle.dylan.api.constant.BoardResponseMessage;
+import jungle.dylan.api.dto.BoardRequest;
+import jungle.dylan.api.dto.BoardResponse;
+import jungle.dylan.api.dto.common.ApiResponse;
+import jungle.dylan.api.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static jungle.dylan.api.constant.BoardResponseMessage.*;
+
+@RestController
+@RequestMapping("/api/v1/board")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @GetMapping
+    public ApiResponse<Object> getBoardAll() {
+        List<BoardResponse> findBoards = boardService.findAll();
+        return ApiResponse.builder()
+                .status(HttpStatus.OK)
+                .data(findBoards)
+                .message(SUCCESS.getMessage())
+                .build();
+    }
+
+    @PostMapping
+    public ApiResponse<Object> write(@RequestBody BoardRequest boardRequest) {
+        BoardResponse writeBoard = boardService.write(boardRequest);
+
+        return ApiResponse.builder()
+                .status(HttpStatus.OK)
+                .data(writeBoard)
+                .message(String.format(WRITE_SUCCESS.getMessage(), writeBoard.getId()))
+                .build();
+    }
+
+}

--- a/src/main/java/jungle/dylan/api/controller/BoardController.java
+++ b/src/main/java/jungle/dylan/api/controller/BoardController.java
@@ -41,4 +41,14 @@ public class BoardController {
                 .build();
     }
 
+    @GetMapping("{id}")
+    public ApiResponse<Object> getBoardById(@PathVariable Long id) {
+        BoardResponse findBoard = boardService.findById(id);
+
+        return ApiResponse.builder()
+                .status(HttpStatus.OK)
+                .data(findBoard)
+                .message(SUCCESS.getMessage())
+                .build();
+    }
 }

--- a/src/main/java/jungle/dylan/api/domain/board/Board.java
+++ b/src/main/java/jungle/dylan/api/domain/board/Board.java
@@ -4,14 +4,20 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Board {
 
     @Id
     @GeneratedValue
+    @Column(name = "board_id")
     Long id;
     String userName;
     String title;

--- a/src/main/java/jungle/dylan/api/domain/board/Board.java
+++ b/src/main/java/jungle/dylan/api/domain/board/Board.java
@@ -24,5 +24,9 @@ public class Board {
     String contents;
     String password;
     LocalDateTime createDate;
-    LocalDateTime updateDate;
+
+    public void update(String title, String contents) {
+        this.title = title;
+        this.contents = contents;
+    }
 }

--- a/src/main/java/jungle/dylan/api/domain/board/Board.java
+++ b/src/main/java/jungle/dylan/api/domain/board/Board.java
@@ -1,0 +1,22 @@
+package jungle.dylan.api.domain.board;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class Board {
+
+    @Id
+    @GeneratedValue
+    Long id;
+    String userName;
+    String title;
+    String contents;
+    String password;
+    LocalDateTime createDate;
+    LocalDateTime updateDate;
+}

--- a/src/main/java/jungle/dylan/api/dto/BoardRequest.java
+++ b/src/main/java/jungle/dylan/api/dto/BoardRequest.java
@@ -1,0 +1,28 @@
+package jungle.dylan.api.dto;
+
+import jungle.dylan.api.domain.board.Board;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class BoardRequest {
+
+    String userName;
+    String title;
+    String contents;
+    String password;
+
+    public Board toEntity() {
+        return Board.builder()
+                .userName(userName)
+                .password(password)
+                .title(title)
+                .contents(contents)
+                .createDate(LocalDateTime.now())
+                .build();
+    }
+
+}

--- a/src/main/java/jungle/dylan/api/dto/BoardResponse.java
+++ b/src/main/java/jungle/dylan/api/dto/BoardResponse.java
@@ -1,0 +1,28 @@
+package jungle.dylan.api.dto;
+
+import jungle.dylan.api.domain.board.Board;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class BoardResponse {
+    Long id;
+    String userName;
+    String title;
+    String contents;
+    LocalDateTime createDate;
+
+    public static BoardResponse of(Board board) {
+        return BoardResponse.builder()
+                .id(board.getId())
+                .userName(board.getUserName())
+                .title(board.getTitle())
+                .contents(board.getContents())
+                .createDate(board.getCreateDate())
+                .build();
+    }
+
+}

--- a/src/main/java/jungle/dylan/api/dto/common/ApiResponse.java
+++ b/src/main/java/jungle/dylan/api/dto/common/ApiResponse.java
@@ -1,0 +1,18 @@
+package jungle.dylan.api.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ApiResponse<T> {
+    private final LocalDateTime time = LocalDateTime.now();
+    private HttpStatus status;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+    private String message;
+}

--- a/src/main/java/jungle/dylan/api/exception/BoardNotFoundException.java
+++ b/src/main/java/jungle/dylan/api/exception/BoardNotFoundException.java
@@ -1,0 +1,24 @@
+package jungle.dylan.api.exception;
+
+
+public class BoardNotFoundException extends RuntimeException{
+    public BoardNotFoundException() {
+        super();
+    }
+
+    public BoardNotFoundException(String message) {
+        super(message);
+    }
+
+    public BoardNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BoardNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    protected BoardNotFoundException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/jungle/dylan/api/repository/BoardRepository.java
+++ b/src/main/java/jungle/dylan/api/repository/BoardRepository.java
@@ -1,0 +1,13 @@
+package jungle.dylan.api.repository;
+
+import jungle.dylan.api.domain.board.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    List<Board> findAllByOrderByCreateDate();
+}

--- a/src/main/java/jungle/dylan/api/service/BoardService.java
+++ b/src/main/java/jungle/dylan/api/service/BoardService.java
@@ -1,0 +1,14 @@
+package jungle.dylan.api.service;
+
+import jungle.dylan.api.dto.BoardRequest;
+import jungle.dylan.api.dto.BoardResponse;
+
+import java.util.List;
+
+public interface BoardService {
+    List<BoardResponse> findAll();
+    BoardResponse write(BoardRequest boardRequest);
+    BoardResponse findById(Long id);
+    BoardResponse update(Long id, BoardRequest boardRequest);
+    Long delete(Long id);
+}

--- a/src/main/java/jungle/dylan/api/service/BoardServiceImpl.java
+++ b/src/main/java/jungle/dylan/api/service/BoardServiceImpl.java
@@ -1,0 +1,65 @@
+package jungle.dylan.api.service;
+
+import jungle.dylan.api.domain.board.Board;
+import jungle.dylan.api.dto.BoardRequest;
+import jungle.dylan.api.dto.BoardResponse;
+import jungle.dylan.api.exception.BoardNotFoundException;
+import jungle.dylan.api.repository.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BoardServiceImpl implements BoardService {
+
+    private final BoardRepository boardRepository;
+
+    @Override
+    public List<BoardResponse> findAll() {
+        List<Board> findBoards = boardRepository.findAllByOrderByCreateDate();
+        return findBoards.stream()
+                .map(b-> BoardResponse.of(b))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public BoardResponse write(BoardRequest boardRequest) {
+        Board board = boardRequest.toEntity();
+        Board savedBoard = boardRepository.save(board);
+
+        return BoardResponse.of(savedBoard);
+    }
+
+    @Override
+    public BoardResponse findById(Long id) {
+        Board board = boardRepository.findById(id).orElseThrow(BoardNotFoundException::new);
+
+        return BoardResponse.of(board);
+    }
+
+    @Override
+    @Transactional
+    public BoardResponse update(Long id, BoardRequest boardRequest) {
+        Board board = boardRepository.findById(id).orElseThrow(BoardNotFoundException::new);
+        board.update(boardRequest.getTitle(), boardRequest.getContents());
+        boardRepository.flush();
+
+        return BoardResponse.of(board);
+    }
+
+    @Override
+    @Transactional
+    public Long delete(Long id) {
+        Board board = boardRepository.findById(id).orElseThrow(()->new BoardNotFoundException());
+        Long boardId = board.getId();
+        boardRepository.delete(board);
+
+        return boardId;
+    }
+}

--- a/src/main/java/jungle/dylan/api/service/BoardServiceImpl.java
+++ b/src/main/java/jungle/dylan/api/service/BoardServiceImpl.java
@@ -47,7 +47,10 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     public BoardResponse update(Long id, BoardRequest boardRequest) {
         Board board = boardRepository.findById(id).orElseThrow(BoardNotFoundException::new);
-        board.update(boardRequest.getTitle(), boardRequest.getContents());
+        if(!board.getPassword().equals(boardRequest.getPassword())){
+            throw new IllegalStateException("Invalid Password");
+        }
+            board.update(boardRequest.getTitle(), boardRequest.getContents());
 
         return BoardResponse.of(board);
     }

--- a/src/main/java/jungle/dylan/api/service/BoardServiceImpl.java
+++ b/src/main/java/jungle/dylan/api/service/BoardServiceImpl.java
@@ -23,7 +23,7 @@ public class BoardServiceImpl implements BoardService {
     public List<BoardResponse> findAll() {
         List<Board> findBoards = boardRepository.findAllByOrderByCreateDate();
         return findBoards.stream()
-                .map(b-> BoardResponse.of(b))
+                .map(BoardResponse::of)
                 .collect(Collectors.toList());
     }
 
@@ -48,7 +48,6 @@ public class BoardServiceImpl implements BoardService {
     public BoardResponse update(Long id, BoardRequest boardRequest) {
         Board board = boardRepository.findById(id).orElseThrow(BoardNotFoundException::new);
         board.update(boardRequest.getTitle(), boardRequest.getContents());
-        boardRepository.flush();
 
         return BoardResponse.of(board);
     }
@@ -56,7 +55,7 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional
     public Long delete(Long id) {
-        Board board = boardRepository.findById(id).orElseThrow(()->new BoardNotFoundException());
+        Board board = boardRepository.findById(id).orElseThrow(BoardNotFoundException::new);
         Long boardId = board.getId();
         boardRepository.delete(board);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=dylan.api

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/jgboard
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        # show_sql: true
+        format_sql: true
+logging.level:
+  org.hibernate.SQL: debug


### PR DESCRIPTION
## Board 도메인 구현 목록

1. 전체 게시글 목록 조회 API
    - 제목, 작성자명, 작성 내용, 작성 날짜를 조회하기
    - 작성 날짜 기준 내림차순으로 정렬하기
2. 게시글 작성 API 
    - 제목, 작성자명, 비밀번호, 작성 내용을 저장하고
    - 저장된 게시글을 Client 로 반환하기
3. 선택한 게시글 조회 API 
    - 선택한 게시글의 제목, 작성자명, 작성 날짜, 작성 내용을 조회하기 
    (검색 기능이 아닙니다. 간단한 게시글 조회만 구현해주세요.)
4. 선택한 게시글 수정 API
    - 수정을 요청할 때 수정할 데이터와 비밀번호를 같이 보내서 서버에서 비밀번호 일치 여부를 확인 한 후
    - 제목, 작성자명, 작성 내용을 수정하고 수정된 게시글을 Client 로 반환하기
5. 선택한 게시글 삭제 API
    - 삭제를 요청할 때 비밀번호를 같이 보내서 서버에서 비밀번호 일치 여부를 확인 한 후
    - 선택한 게시글을 삭제하고 Client 로 성공했다는 표시 반환하기