### PR TITLE
User 도메인 설계 및 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
@@ -33,6 +33,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/jungle/dylan/api/Application.java
+++ b/src/main/java/jungle/dylan/api/Application.java
@@ -2,8 +2,9 @@ package jungle.dylan.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/jungle/dylan/api/auth/JwtProvider.java
+++ b/src/main/java/jungle/dylan/api/auth/JwtProvider.java
@@ -1,0 +1,128 @@
+package jungle.dylan.api.auth;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jungle.dylan.api.domain.user.User;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static jungle.dylan.api.constant.auth.JwtConst.ACCESS_TOKEN_EXPIRE_TIME;
+import static jungle.dylan.api.constant.auth.JwtConst.REFRESH_TOKEN_EXPIRE_TIME;
+
+@Slf4j
+@Component
+public class JwtProvider {
+    private final Key key;
+
+    public JwtProvider(@Value("${jwt.secret}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public Token generateToken(Authentication authentication) {
+
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = new Date().getTime();
+        Date accessTokenExpireIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME.getTime());
+        Date refreshTokenExpireIn = new Date(now + REFRESH_TOKEN_EXPIRE_TIME.getTime());
+
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("role", authorities)
+                .setExpiration(accessTokenExpireIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setExpiration(refreshTokenExpireIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return Token.builder()
+//                .grantType("Bearer")
+                .accessToken(accessToken)
+//                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public String generateToken(String username) {
+
+
+        long now = new Date().getTime();
+        Date accessTokenExpireIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME.getTime());
+        Date refreshTokenExpireIn = new Date(now + REFRESH_TOKEN_EXPIRE_TIME.getTime());
+
+        String accessToken = Jwts.builder()
+                .setSubject(username)
+                .setExpiration(accessTokenExpireIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return accessToken;
+    }
+
+//    public Authentication getAuthentication(String accessToken) {
+//        Claims claims = parseClaims(accessToken);
+//
+//        if(claims.get("role") == null)
+//            throw new RuntimeException("There are no auth information");
+//
+//        List<SimpleGrantedAuthority> authorities = Arrays.stream(claims.get("role").toString().split(","))
+//                .map(SimpleGrantedAuthority::new)
+//                .collect(Collectors.toList());
+//
+//        UserDetails principal = User.builder()
+//                .username(claims.getSubject())
+//                .password("")
+//                .build();
+//
+//        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+//    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/jungle/dylan/api/constant/UserResponseMessage.java
+++ b/src/main/java/jungle/dylan/api/constant/UserResponseMessage.java
@@ -1,0 +1,14 @@
+package jungle.dylan.api.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserResponseMessage {
+    JOIN_SUCCESS("join success"),
+    LOGIN_SUCCESS("login success"),
+    ;
+
+    private final String message;
+}

--- a/src/main/java/jungle/dylan/api/constant/auth/JwtConst.java
+++ b/src/main/java/jungle/dylan/api/constant/auth/JwtConst.java
@@ -1,0 +1,13 @@
+package jungle.dylan.api.constant.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtConst {
+    ACCESS_TOKEN_EXPIRE_TIME(3600000),
+    REFRESH_TOKEN_EXPIRE_TIME(3600000 * 24);
+
+    private final long time;
+}

--- a/src/main/java/jungle/dylan/api/controller/BoardController.java
+++ b/src/main/java/jungle/dylan/api/controller/BoardController.java
@@ -1,6 +1,5 @@
 package jungle.dylan.api.controller;
 
-import jungle.dylan.api.constant.BoardResponseMessage;
 import jungle.dylan.api.dto.BoardRequest;
 import jungle.dylan.api.dto.BoardResponse;
 import jungle.dylan.api.dto.common.ApiResponse;

--- a/src/main/java/jungle/dylan/api/controller/UserController.java
+++ b/src/main/java/jungle/dylan/api/controller/UserController.java
@@ -1,0 +1,44 @@
+package jungle.dylan.api.controller;
+
+import jakarta.validation.Valid;
+import jungle.dylan.api.constant.UserResponseMessage;
+import jungle.dylan.api.dto.UserRequest;
+import jungle.dylan.api.dto.common.ApiResponse;
+import jungle.dylan.api.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static jungle.dylan.api.constant.UserResponseMessage.*;
+
+@RestController
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/join")
+    public ApiResponse<Object> join(@RequestBody @Valid UserRequest userRequest) {
+        userService.join(userRequest);
+
+        return ApiResponse.builder()
+                .status(HttpStatus.OK)
+                .message(JOIN_SUCCESS.getMessage())
+                .build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(@RequestBody UserRequest userRequest) {
+        String token = userService.login(userRequest);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", token);
+
+        return new ResponseEntity<String>(LOGIN_SUCCESS.getMessage(), headers, HttpStatus.OK);
+    }
+}

--- a/src/main/java/jungle/dylan/api/domain/board/Board.java
+++ b/src/main/java/jungle/dylan/api/domain/board/Board.java
@@ -1,9 +1,6 @@
 package jungle.dylan.api.domain.board;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -18,12 +15,12 @@ public class Board {
     @Id
     @GeneratedValue
     @Column(name = "board_id")
-    Long id;
-    String userName;
-    String title;
-    String contents;
-    String password;
-    LocalDateTime createDate;
+    private Long id;
+    private String username;
+    private String title;
+    private String contents;
+    private String password;
+    private LocalDateTime createDate;
 
     public void update(String title, String contents) {
         this.title = title;

--- a/src/main/java/jungle/dylan/api/domain/user/User.java
+++ b/src/main/java/jungle/dylan/api/domain/user/User.java
@@ -1,0 +1,25 @@
+package jungle.dylan.api.domain.user;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue
+    @Column(name = "user_id")
+    Long id;
+    @Column(unique = true)
+    String username;
+    String password;
+    LocalDateTime createDate;
+
+}

--- a/src/main/java/jungle/dylan/api/dto/BoardRequest.java
+++ b/src/main/java/jungle/dylan/api/dto/BoardRequest.java
@@ -10,14 +10,14 @@ import java.time.LocalDateTime;
 @Builder
 public class BoardRequest {
 
-    String userName;
+    String username;
     String title;
     String contents;
     String password;
 
     public Board toEntity() {
         return Board.builder()
-                .userName(userName)
+                .username(username)
                 .password(password)
                 .title(title)
                 .contents(contents)

--- a/src/main/java/jungle/dylan/api/dto/BoardResponse.java
+++ b/src/main/java/jungle/dylan/api/dto/BoardResponse.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @Builder
 public class BoardResponse {
     Long id;
-    String userName;
+    String username;
     String title;
     String contents;
     LocalDateTime createDate;
@@ -18,7 +18,7 @@ public class BoardResponse {
     public static BoardResponse of(Board board) {
         return BoardResponse.builder()
                 .id(board.getId())
-                .userName(board.getUserName())
+                .username(board.getUsername())
                 .title(board.getTitle())
                 .contents(board.getContents())
                 .createDate(board.getCreateDate())

--- a/src/main/java/jungle/dylan/api/dto/UserRequest.java
+++ b/src/main/java/jungle/dylan/api/dto/UserRequest.java
@@ -1,0 +1,26 @@
+package jungle.dylan.api.dto;
+
+import jakarta.validation.constraints.Pattern;
+import jungle.dylan.api.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@Builder
+public class UserRequest {
+    @Pattern(regexp = "^[a-z0-9]{4,10}$", message = "Username must be between 4 and 10 characters long and contain only lowercase letters and digits.")
+    private String username;
+    @Pattern(regexp = "^[a-zA-Z0-9]{8,15}$", message = "Password must be between 8 and 15 characters long and contain only letters and digits.")
+    private String password;
+
+    public User createUser() {
+        return User.builder()
+                .username(username)
+                .password(password)
+                .createDate(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/jungle/dylan/api/dto/common/ApiResponse.java
+++ b/src/main/java/jungle/dylan/api/dto/common/ApiResponse.java
@@ -1,8 +1,10 @@
 package jungle.dylan.api.dto.common;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
@@ -10,9 +12,11 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class ApiResponse<T> {
-    private final LocalDateTime time = LocalDateTime.now();
+    @JsonIgnore
+    private HttpHeaders headers;
     private HttpStatus status;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private T data;
     private String message;
+    private final LocalDateTime time = LocalDateTime.now();
 }

--- a/src/main/java/jungle/dylan/api/exception/DuplicateUsernameException.java
+++ b/src/main/java/jungle/dylan/api/exception/DuplicateUsernameException.java
@@ -1,0 +1,23 @@
+package jungle.dylan.api.exception;
+
+public class DuplicateUsernameException extends RuntimeException{
+    public DuplicateUsernameException() {
+        super();
+    }
+
+    public DuplicateUsernameException(String message) {
+        super(message);
+    }
+
+    public DuplicateUsernameException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DuplicateUsernameException(Throwable cause) {
+        super(cause);
+    }
+
+    protected DuplicateUsernameException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/jungle/dylan/api/exception/InvalidPasswordException.java
+++ b/src/main/java/jungle/dylan/api/exception/InvalidPasswordException.java
@@ -1,0 +1,23 @@
+package jungle.dylan.api.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException() {
+        super();
+    }
+
+    public InvalidPasswordException(String message) {
+        super(message);
+    }
+
+    public InvalidPasswordException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidPasswordException(Throwable cause) {
+        super(cause);
+    }
+
+    protected InvalidPasswordException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/jungle/dylan/api/exception/UserNotFoundException.java
+++ b/src/main/java/jungle/dylan/api/exception/UserNotFoundException.java
@@ -1,0 +1,23 @@
+package jungle.dylan.api.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException() {
+        super();
+    }
+
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+
+    public UserNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UserNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    protected UserNotFoundException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/jungle/dylan/api/repository/UserRepository.java
+++ b/src/main/java/jungle/dylan/api/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package jungle.dylan.api.repository;
+
+import jungle.dylan.api.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findUserByUsername(String username);
+}

--- a/src/main/java/jungle/dylan/api/service/UserService.java
+++ b/src/main/java/jungle/dylan/api/service/UserService.java
@@ -1,0 +1,9 @@
+package jungle.dylan.api.service;
+
+import jungle.dylan.api.dto.UserRequest;
+
+public interface UserService {
+    Long join(UserRequest userRequest);
+    String login(UserRequest userRequest);
+
+}

--- a/src/main/java/jungle/dylan/api/service/impl/BoardServiceImpl.java
+++ b/src/main/java/jungle/dylan/api/service/impl/BoardServiceImpl.java
@@ -1,10 +1,11 @@
-package jungle.dylan.api.service;
+package jungle.dylan.api.service.impl;
 
 import jungle.dylan.api.domain.board.Board;
 import jungle.dylan.api.dto.BoardRequest;
 import jungle.dylan.api.dto.BoardResponse;
 import jungle.dylan.api.exception.BoardNotFoundException;
 import jungle.dylan.api.repository.BoardRepository;
+import jungle.dylan.api.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/jungle/dylan/api/service/impl/UserServiceImpl.java
+++ b/src/main/java/jungle/dylan/api/service/impl/UserServiceImpl.java
@@ -1,0 +1,46 @@
+package jungle.dylan.api.service.impl;
+
+import jungle.dylan.api.auth.JwtProvider;
+import jungle.dylan.api.domain.user.User;
+import jungle.dylan.api.dto.UserRequest;
+import jungle.dylan.api.exception.DuplicateUsernameException;
+import jungle.dylan.api.exception.InvalidPasswordException;
+import jungle.dylan.api.exception.UserNotFoundException;
+import jungle.dylan.api.repository.UserRepository;
+import jungle.dylan.api.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    @Transactional
+    public Long join(UserRequest userRequest) {
+        Optional<User> findUser = userRepository.findUserByUsername(userRequest.getUsername());
+        if (findUser.isPresent()) {
+            throw new DuplicateUsernameException();
+        }
+        User user = userRequest.createUser();
+        User saveUser = userRepository.save(user);
+        return saveUser.getId();
+    }
+
+    @Override
+    public String login(UserRequest userRequest) {
+        User user = userRepository.findUserByUsername(userRequest.getUsername())
+                .orElseThrow(UserNotFoundException::new);
+        if (!user.getPassword().equals(userRequest.getPassword())) {
+            throw new InvalidPasswordException();
+        }
+        return jwtProvider.generateToken(user.getUsername());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,6 @@ spring:
         format_sql: true
 logging.level:
   org.hibernate.SQL: debug
+
+jwt:
+  secret: 26d4093d0c208a5fc4664950c07ef18d694f4866623fd65e70c9b3402ce69384


### PR DESCRIPTION
## User 설계 및 구현

#### User 도메인 설계
- username을 unique로 한다.
- password는 현재 단계에서는 평문으로 저장

#### User 기능 구현
1. 회원 가입 API
    - username, password를 Client에서 전달받기
    - username은  `최소 4자 이상, 10자 이하이며 알파벳 소문자(a~z), 숫자(0~9)`로 구성되어야 한다.
    - password는  `최소 8자 이상, 15자 이하이며 알파벳 대소문자(a~z, A~Z), 숫자(0~9)`로 구성되어야 한다.
    - DB에 중복된 username이 없다면 회원을 저장하고 Client 로 성공했다는 메시지, 상태코드 반환하기

2. 로그인 API
    - username, password를 Client에서 전달받기
    - DB에서 username을 사용하여 저장된 회원의 유무를 확인하고 있다면 password 비교하기
    - 로그인 성공 시, 로그인에 성공한 유저의 정보와 JWT를 활용하여 토큰을 발급하고, 
    발급한 토큰을 Header에 추가하고 성공했다는 메시지, 상태코드 와 함께 Client에 반환하기