### PR TITLE
Board Api 기능 확장

### DIFF
--- a/src/main/java/jungle/dylan/api/domain/board/Board.java
+++ b/src/main/java/jungle/dylan/api/domain/board/Board.java
@@ -1,10 +1,13 @@
 package jungle.dylan.api.domain.board;
 
 import jakarta.persistence.*;
+import jungle.dylan.api.domain.comment.Comment;
 import jungle.dylan.api.domain.user.User;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
 
@@ -25,6 +28,8 @@ public class Board {
     private User user;
     private String title;
     private String contents;
+    @OneToMany(mappedBy = "board",cascade = CascadeType.ALL)
+    private List<Comment> comments = new ArrayList<>();
     private String password;
     private LocalDateTime createDate;
 

--- a/src/main/java/jungle/dylan/api/domain/board/Board.java
+++ b/src/main/java/jungle/dylan/api/domain/board/Board.java
@@ -22,7 +22,6 @@ public class Board {
     @GeneratedValue
     @Column(name = "board_id")
     private Long id;
-    private String writer;
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -30,11 +29,9 @@ public class Board {
     private String contents;
     @OneToMany(mappedBy = "board",cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
-    private String password;
     private LocalDateTime createDate;
 
-    public void update(String writer, String title, String contents) {
-        this.writer = writer;
+    public void update(String title, String contents) {
         this.title = title;
         this.contents = contents;
     }

--- a/src/main/java/jungle/dylan/api/domain/user/Role.java
+++ b/src/main/java/jungle/dylan/api/domain/user/Role.java
@@ -1,5 +1,8 @@
 package jungle.dylan.api.domain.user;
 
+import lombok.ToString;
+
+@ToString
 public enum Role {
     USER, ADMIN
 }

--- a/src/main/java/jungle/dylan/api/domain/user/User.java
+++ b/src/main/java/jungle/dylan/api/domain/user/User.java
@@ -16,12 +16,12 @@ public class User {
     @Id
     @GeneratedValue
     @Column(name = "user_id")
-    Long id;
+    private Long id;
     @Column(unique = true)
-    String username;
-    String password;
+    private String username;
+    private String password;
     @Enumerated(EnumType.STRING)
-    Role role;
-    LocalDateTime createDate;
+    private Role role = Role.USER;
+    private LocalDateTime createDate;
 
 }

--- a/src/main/java/jungle/dylan/api/dto/BoardRequest.java
+++ b/src/main/java/jungle/dylan/api/dto/BoardRequest.java
@@ -1,6 +1,7 @@
 package jungle.dylan.api.dto;
 
 import jungle.dylan.api.domain.board.Board;
+import jungle.dylan.api.domain.user.User;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,15 +11,12 @@ import java.time.LocalDateTime;
 @Builder
 public class BoardRequest {
 
-    String writer;
     String title;
     String contents;
-    String password;
 
-    public Board toEntity() {
+    public Board toEntity(User user) {
         return Board.builder()
-                .writer(writer)
-                .password(password)
+                .user(user)
                 .title(title)
                 .contents(contents)
                 .createDate(LocalDateTime.now())

--- a/src/main/java/jungle/dylan/api/dto/BoardResponse.java
+++ b/src/main/java/jungle/dylan/api/dto/BoardResponse.java
@@ -2,10 +2,15 @@ package jungle.dylan.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jungle.dylan.api.domain.board.Board;
+import jungle.dylan.api.domain.comment.Comment;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -14,17 +19,26 @@ public class BoardResponse {
     String writer;
     String title;
     String contents;
+    List<CommentResponse> comments;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     LocalDateTime createDate;
 
     public static BoardResponse of(Board board) {
+        List<Comment> comments = board.getComments();
+        List<CommentResponse> commentResponses = Collections.emptyList();
+        if (comments != null) {
+            commentResponses = comments.stream()
+                    .map(CommentResponse::of)
+                    .collect(Collectors.toList());
+        }
+
         return BoardResponse.builder()
                 .id(board.getId())
                 .writer(board.getWriter())
                 .title(board.getTitle())
                 .contents(board.getContents())
                 .createDate(board.getCreateDate())
+                .comments(commentResponses)
                 .build();
     }
-
 }

--- a/src/main/java/jungle/dylan/api/dto/BoardResponse.java
+++ b/src/main/java/jungle/dylan/api/dto/BoardResponse.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,7 +15,7 @@ import java.util.stream.Collectors;
 @Builder
 public class BoardResponse {
     Long id;
-    String writer;
+    String username;
     String title;
     String contents;
     List<CommentResponse> comments;
@@ -34,7 +33,7 @@ public class BoardResponse {
 
         return BoardResponse.builder()
                 .id(board.getId())
-                .writer(board.getWriter())
+                .username(board.getUser().getUsername())
                 .title(board.getTitle())
                 .contents(board.getContents())
                 .createDate(board.getCreateDate())

--- a/src/main/java/jungle/dylan/api/service/impl/BoardServiceImpl.java
+++ b/src/main/java/jungle/dylan/api/service/impl/BoardServiceImpl.java
@@ -1,12 +1,19 @@
 package jungle.dylan.api.service.impl;
 
 import jungle.dylan.api.domain.board.Board;
+import jungle.dylan.api.domain.user.Role;
+import jungle.dylan.api.domain.user.User;
 import jungle.dylan.api.dto.BoardRequest;
 import jungle.dylan.api.dto.BoardResponse;
 import jungle.dylan.api.exception.BoardNotFoundException;
+import jungle.dylan.api.exception.UserNotFoundException;
 import jungle.dylan.api.repository.BoardRepository;
+import jungle.dylan.api.repository.UserRepository;
 import jungle.dylan.api.service.BoardService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +26,7 @@ import java.util.stream.Collectors;
 public class BoardServiceImpl implements BoardService {
 
     private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
 
     @Override
     public List<BoardResponse> findAll() {
@@ -31,7 +39,8 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional
     public BoardResponse write(BoardRequest boardRequest) {
-        Board board = boardRequest.toEntity();
+        User currentUser = getCurrentUser();
+        Board board = boardRequest.toEntity(currentUser);
         Board savedBoard = boardRepository.save(board);
 
         return BoardResponse.of(savedBoard);
@@ -48,10 +57,11 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     public BoardResponse update(Long id, BoardRequest boardRequest) {
         Board board = boardRepository.findById(id).orElseThrow(BoardNotFoundException::new);
-        if(!board.getPassword().equals(boardRequest.getPassword())){
+        User currentUser = getCurrentUser();
+        if(currentUser.getRole().equals(Role.USER) && !currentUser.equals(board.getUser())){
             throw new IllegalStateException("Invalid Password");
         }
-            board.update(boardRequest.getWriter(), boardRequest.getTitle(), boardRequest.getContents());
+            board.update(boardRequest.getTitle(), boardRequest.getContents());
 
         return BoardResponse.of(board);
     }
@@ -60,9 +70,28 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     public Long delete(Long id) {
         Board board = boardRepository.findById(id).orElseThrow(BoardNotFoundException::new);
+        User currentUser = getCurrentUser();
+        if(currentUser.getRole().equals(Role.USER) && !currentUser.equals(board.getUser())){
+            throw new IllegalStateException("Invalid Password");
+        }
         Long boardId = board.getId();
         boardRepository.delete(board);
 
         return boardId;
+    }
+
+    private User getCurrentUser() {
+        User currentUser = null;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.isAuthenticated()) {
+            UserDetails principal = (UserDetails) authentication.getPrincipal();
+            System.out.println(principal.getUsername());
+            currentUser = userRepository.findUserByUsername(principal.getUsername())
+                    .orElseThrow(UserNotFoundException::new);
+
+        }
+
+        return currentUser;
     }
 }

--- a/src/main/java/jungle/dylan/api/service/impl/CommentServiceImpl.java
+++ b/src/main/java/jungle/dylan/api/service/impl/CommentServiceImpl.java
@@ -2,6 +2,7 @@ package jungle.dylan.api.service.impl;
 
 import jungle.dylan.api.domain.board.Board;
 import jungle.dylan.api.domain.comment.Comment;
+import jungle.dylan.api.domain.user.Role;
 import jungle.dylan.api.domain.user.User;
 import jungle.dylan.api.dto.CommentUpdateRequest;
 import jungle.dylan.api.dto.CommentWriteRequest;
@@ -50,7 +51,7 @@ public class CommentServiceImpl implements CommentService {
                 .orElseThrow(CommentNotFoundException::new);
 
         User currentUser = getCurrentUser();
-        if (!currentUser.equals(findComment.getUser())) {
+        if (currentUser.getRole().equals(Role.USER) && !currentUser.equals(findComment.getUser())) {
             throw new RuntimeException("권한없음"); // 수정 필요
         }
 
@@ -65,7 +66,7 @@ public class CommentServiceImpl implements CommentService {
         Long deletedId = findComment.getId();
         User currentUser = getCurrentUser();
 
-        if (!currentUser.equals(findComment.getUser())) {
+        if (currentUser.getRole().equals(Role.USER) && !currentUser.equals(findComment.getUser())) {
             throw new RuntimeException("권한없음"); // 수정 필요
         }
 


### PR DESCRIPTION
## Board 확장 내용
1. Board 조회 시 해당 글에 연관된 댓글 함께 조회
2. Board 수정 및 삭제 시 현재 인증 토큰을 확인해 수정 / 삭제 권한이 있는지 확인 후 수정 및 삭제
3. 임의의 작성자명을 입력 받는 방식에서 로그인한 username을 저장하도록 수정